### PR TITLE
refactor(screens): renomeia telas EN→PT-BR e atualiza rotas/imports

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -8,16 +8,16 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Image } from 'react-native';
 import bell from '../assets/bell.png';
 import newspaper from '../assets/newspaper.png';
-import { Home } from './screens/Home';
-import { Profile } from './screens/Profile';
-import { Settings } from './screens/Settings';
-import { Updates } from './screens/Updates';
-import { NotFound } from './screens/NotFound';
+import { TelaInicial } from './screens/TelaInicial';
+import { Perfil } from './screens/Perfil';
+import { Configuracoes } from './screens/Configuracoes';
+import { Notificacoes } from './screens/Notificacoes';
+import { NaoEncontrado } from './screens/NaoEncontrado';
 
 const HomeTabs = createBottomTabNavigator({
   screens: {
-    Home: {
-      screen: Home,
+    TelaInicial: {
+      screen: TelaInicial,
       options: {
         title: 'Feed',
         tabBarIcon: ({ color, size }) => (
@@ -32,8 +32,8 @@ const HomeTabs = createBottomTabNavigator({
         ),
       },
     },
-    Updates: {
-      screen: Updates,
+    Notificacoes: {
+      screen: Notificacoes,
       options: {
         tabBarIcon: ({ color, size }) => (
           <Image
@@ -59,8 +59,8 @@ const RootStack = createNativeStackNavigator({
         headerShown: false,
       },
     },
-    Profile: {
-      screen: Profile,
+    Perfil: {
+      screen: Perfil,
       linking: {
         path: ':user(@[a-zA-Z0-9-_]+)',
         parse: {
@@ -71,8 +71,8 @@ const RootStack = createNativeStackNavigator({
         },
       },
     },
-    Settings: {
-      screen: Settings,
+    Configuracoes: {
+      screen: Configuracoes,
       options: ({ navigation }) => ({
         presentation: 'modal',
         headerRight: () => (
@@ -82,8 +82,8 @@ const RootStack = createNativeStackNavigator({
         ),
       }),
     },
-    NotFound: {
-      screen: NotFound,
+    NaoEncontrado: {
+      screen: NaoEncontrado,
       options: {
         title: '404',
       },

--- a/src/navigation/screens/Configuracoes.tsx
+++ b/src/navigation/screens/Configuracoes.tsx
@@ -1,10 +1,10 @@
 import { Text } from '@react-navigation/elements';
 import { StyleSheet, View } from 'react-native';
 
-export function Settings() {
+export function Configuracoes() {
   return (
     <View style={styles.container}>
-      <Text>Settings Screen</Text>
+      <Text>Tela Configuracoes</Text>
     </View>
   );
 }

--- a/src/navigation/screens/NaoEncontrado.tsx
+++ b/src/navigation/screens/NaoEncontrado.tsx
@@ -1,11 +1,11 @@
 import { Text, Button } from '@react-navigation/elements';
 import { StyleSheet, View } from 'react-native';
 
-export function NotFound() {
+export function NaoEncontrado() {
   return (
     <View style={styles.container}>
       <Text>404</Text>
-      <Button screen="HomeTabs">Go to Home</Button>
+      <Button screen="HomeTabs">Ir para Home</Button>
     </View>
   );
 }

--- a/src/navigation/screens/Notificacoes.tsx
+++ b/src/navigation/screens/Notificacoes.tsx
@@ -1,15 +1,10 @@
 import { Text } from '@react-navigation/elements';
-import { StaticScreenProps } from '@react-navigation/native';
 import { StyleSheet, View } from 'react-native';
 
-type Props = StaticScreenProps<{
-  user: string;
-}>;
-
-export function Profile({ route }: Props) {
+export function Notificacoes() {
   return (
     <View style={styles.container}>
-      <Text>{route.params.user}'s Profile</Text>
+      <Text>Tela Notificacoes</Text>
     </View>
   );
 }

--- a/src/navigation/screens/Perfil.tsx
+++ b/src/navigation/screens/Perfil.tsx
@@ -1,10 +1,15 @@
 import { Text } from '@react-navigation/elements';
+import { StaticScreenProps } from '@react-navigation/native';
 import { StyleSheet, View } from 'react-native';
 
-export function Updates() {
+type PerfilProps = StaticScreenProps<{
+  user: string;
+}>;
+
+export function Perfil({ route }: PerfilProps) {
   return (
     <View style={styles.container}>
-      <Text>Updates Screen</Text>
+      <Text>Perfil de {route.params.user}</Text>
     </View>
   );
 }

--- a/src/navigation/screens/TelaInicial.tsx
+++ b/src/navigation/screens/TelaInicial.tsx
@@ -1,15 +1,15 @@
 import { Button, Text } from '@react-navigation/elements';
 import { StyleSheet, View } from 'react-native';
 
-export function Home() {
+export function TelaInicial() {
   return (
     <View style={styles.container}>
-      <Text>Home Screen</Text>
-      <Text>Open up 'src/App.tsx' to start working on your app!</Text>
-      <Button screen="Profile" params={{ user: 'jane' }}>
-        Go to Profile
+      <Text>Tela Inicial</Text>
+      <Text>Abra 'src/App.tsx' para começar a trabalhar no seu app!</Text>
+      <Button screen="Perfil" params={{ user: 'jane' }}>
+        Ir para Perfil
       </Button>
-      <Button screen="Settings">Go to Settings</Button>
+      <Button screen="Configuracoes">Ir para Configurações</Button>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- rename screens from English to Portuguese and update component names
- adjust navigation routes and references to new screen names

## Testing
- `npm run lint` (fails: Missing script)
- `npx tsc --noEmit`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a06ead033c832088baf090913e2bb9