### PR TITLE
Fix login navigation to feed screen

### DIFF
--- a/src/screens/TelaLogin.tsx
+++ b/src/screens/TelaLogin.tsx
@@ -16,7 +16,7 @@ export default function TelaLogin({ navigation }: any) {
   const pressOut = () => Animated.spring(btnScale, { toValue: 1, friction: 3, useNativeDriver: true }).start();
 
   const onEntrar = () => {
-    navigation.replace('Telainicial');
+    navigation.replace('RootTabs');
   };
 
   return (


### PR DESCRIPTION
## Summary
- Correct login navigation to load RootTabs, showing the feed after login

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc78d6708320856da198968cad70