### PR TITLE
fix: wrap navigation with gesture root

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useColorScheme } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import KachanTabs from '@/navigation/KachanTabs';
 import TelaLogin from '@/screens/TelaLogin';
 import StoryViewer from '@/screens/StoryViewer';
@@ -19,12 +20,14 @@ export default function App() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? DarkTheme : DefaultTheme;
   return (
-    <NavigationContainer theme={theme}>
-      <Stack.Navigator initialRouteName="TelaLogin" screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="TelaLogin" component={TelaLogin} />
-        <Stack.Screen name="RootTabs" component={KachanTabs} />
-        <Stack.Screen name="StoryViewer" component={StoryViewer as any} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer theme={theme}>
+        <Stack.Navigator initialRouteName="TelaLogin" screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="TelaLogin" component={TelaLogin} />
+          <Stack.Screen name="RootTabs" component={KachanTabs} />
+          <Stack.Screen name="StoryViewer" component={StoryViewer as any} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- wrap app navigation in GestureHandlerRootView to avoid blank screens

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc --noEmit`


------
