### PR TITLE
Fix blank screen by initializing gesture handler and reanimated

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,3 +1,5 @@
+import 'react-native-gesture-handler';
+import 'react-native-reanimated';
 import '@expo/metro-runtime'; // Necessary for Fast Refresh on Web
 import { registerRootComponent } from 'expo';
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import 'react-native-gesture-handler';
 import React from 'react';
 import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';


### PR DESCRIPTION
## Summary
- initialize react-native-gesture-handler and react-native-reanimated at app entry
- remove redundant gesture handler import from App component

## Testing
- `npx expo export --platform web`


------
https://chatgpt.com/codex/tasks/task_e_68a0cf6b847083208f1b6be3aa12ac9f