### PR TITLE
fix: resolve reanimated babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin'],
+    plugins: [require.resolve('react-native-reanimated/plugin')],
   };
 };


### PR DESCRIPTION
## Summary
- ensure Babel resolves react-native-reanimated plugin with absolute path

## Testing
- `npm test` *(fails: Missing script "test")*


------
