### PR TITLE
Add create flow stack routes and navigation

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,10 +1,11 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { HeaderButton, Text } from '@react-navigation/elements';
+import { useNavigation } from '@react-navigation/native';
+import { createStaticNavigation } from '@react-navigation/native';
 import {
-  createStaticNavigation,
-  StaticParamList,
-} from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+  createNativeStackNavigator,
+  type NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
 import { Image } from 'react-native';
 import bell from '../assets/bell.png';
 import newspaper from '../assets/newspaper.png';
@@ -13,6 +14,24 @@ import { Perfil } from './screens/Perfil';
 import { Configuracoes } from './screens/Configuracoes';
 import { Notificacoes } from './screens/Notificacoes';
 import { NaoEncontrado } from './screens/NaoEncontrado';
+import Criar from '../screens/Criar';
+import CriarStories from '../screens/CriarStories';
+import CriarPostagem from '../screens/CriarPostagem';
+import CriarShorts from '../screens/CriarShorts';
+import LiveSetup from '../screens/LiveSetup';
+
+export type RootStackParamList = {
+  HomeTabs: undefined;
+  Criar: undefined;
+  CriarStories: undefined;
+  CriarPostagem: undefined;
+  CriarShorts: undefined;
+  LiveSetup: undefined;
+  Perfil: { user: string };
+  Configuracoes: undefined;
+  Notificacoes: undefined;
+  NaoEncontrado: undefined;
+};
 
 const HomeTabs = createBottomTabNavigator({
   screens: {
@@ -82,6 +101,36 @@ const RootStack = createNativeStackNavigator({
         ),
       }),
     },
+    Criar: {
+      screen: Criar,
+      options: {
+        title: 'Criar',
+      },
+    },
+    CriarStories: {
+      screen: CriarStories,
+      options: {
+        title: 'Criar Stories',
+      },
+    },
+    CriarPostagem: {
+      screen: CriarPostagem,
+      options: {
+        title: 'Criar Postagem',
+      },
+    },
+    CriarShorts: {
+      screen: CriarShorts,
+      options: {
+        title: 'Criar Shorts',
+      },
+    },
+    LiveSetup: {
+      screen: LiveSetup,
+      options: {
+        title: 'Live Streamer',
+      },
+    },
     NaoEncontrado: {
       screen: NaoEncontrado,
       options: {
@@ -96,7 +145,9 @@ const RootStack = createNativeStackNavigator({
 
 export const Navigation = createStaticNavigation(RootStack);
 
-type RootStackParamList = StaticParamList<typeof RootStack>;
+export function useAppNavigation() {
+  return useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+}
 
 declare global {
   namespace ReactNavigation {

--- a/src/screens/Criar.tsx
+++ b/src/screens/Criar.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { Ionicons } from "@expo/vector-icons";
+import { useAppNavigation } from "../navigation";
 
 const { width } = Dimensions.get("window");
 
@@ -18,6 +19,7 @@ const { width } = Dimensions.get("window");
 const TAB_BAR_HEIGHT = 86;
 
 export default function CreateScreen() {
+  const navigation = useAppNavigation();
   const OptionCard = ({
     icon,
     title,
@@ -83,25 +85,25 @@ export default function CreateScreen() {
             icon="game-controller-outline"
             title="Live Streamer"
             subtitle="Transmita seus jogos ao vivo"
-            onPress={() => {}}
+            onPress={() => navigation.navigate("LiveSetup")}
           />
           <OptionCard
             icon="camera-outline"
             title="Criar Stories"
             subtitle="Compartilhe momentos rápidos"
-            onPress={() => {}}
+            onPress={() => navigation.navigate("CriarStories")}
           />
           <OptionCard
             icon="create-outline"
             title="Criar Postagem"
             subtitle="Compartilhe no feed"
-            onPress={() => {}}
+            onPress={() => navigation.navigate("CriarPostagem")}
           />
           <OptionCard
             icon="film-outline"
             title="Criar Shorts"
             subtitle="Grave ou envie vídeos curtos"
-            onPress={() => {}}
+            onPress={() => navigation.navigate("CriarShorts")}
             isLast
           />
         </View>

--- a/src/screens/LiveSetup.tsx
+++ b/src/screens/LiveSetup.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function LiveSetup() {
+  return (
+    <View style={styles.root}>
+      <Text style={styles.title}>Live Streamer</Text>
+      <Text style={styles.sub}>Configuração de live em breve.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#0E0E12', alignItems: 'center', justifyContent: 'center' },
+  title: { color: '#fff', fontSize: 22, fontWeight: '800' },
+  sub: { color: '#A6ADCE', marginTop: 6 },
+});


### PR DESCRIPTION
## Summary
- register create flow screens in root stack and type routes
- add typed navigation helper and connect create screen buttons
- stub Live setup screen placeholder

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Type error in src/screens/Shorts.tsx unrelated to this change)*

------
