### PR TITLE
Wire up creation screens in navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,19 @@ import { useColorScheme } from 'react-native';
 import KachanTabs from '@/navigation/KachanTabs';
 import TelaLogin from '@/screens/TelaLogin';
 import StoryViewer from '@/screens/StoryViewer';
+import CriarStories from '@/screens/CriarStories';
+import CriarPostagem from '@/screens/CriarPostagem';
+import CriarShorts from '@/screens/CriarShorts';
+import LiveSetup from '@/screens/LiveSetup';
 
 export type RootStackParamList = {
   TelaLogin: undefined;
   RootTabs: undefined;
   StoryViewer: any;
+  CriarStories: undefined;
+  CriarPostagem: undefined;
+  CriarShorts: undefined;
+  LiveSetup: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -24,6 +32,10 @@ export default function App() {
         <Stack.Screen name="TelaLogin" component={TelaLogin} />
         <Stack.Screen name="RootTabs" component={KachanTabs} />
         <Stack.Screen name="StoryViewer" component={StoryViewer as any} />
+        <Stack.Screen name="CriarStories" component={CriarStories} />
+        <Stack.Screen name="CriarPostagem" component={CriarPostagem} />
+        <Stack.Screen name="CriarShorts" component={CriarShorts} />
+        <Stack.Screen name="LiveSetup" component={LiveSetup} />
       </Stack.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
## Summary
- Register creation flow screens (stories, posts, shorts, live setup) in root stack
- Ensure Create options navigate to their respective screens

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a68b734b0c8320a49077ca23f9ce8c